### PR TITLE
Remove callback to make convert() cleaner

### DIFF
--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -60,41 +60,48 @@ module.exports = {
 
   convert: function() {
     try{
-      outPath = getOutputPath();
-      getHtml(function(html){
-        html = convertImgSrcToURI(html);
-        html = getStyledHtml(html);
+      var outPath = getOutputPath();
 
-        // Ugly Fix 1:
-        base64hr = 'iVBORw0KGgoAAAANSUhEUgAAAAYAAAAECAYAAACtBE5DAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6OENDRjNBN0E2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6OENDRjNBN0I2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo4Q0NGM0E3ODY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo4Q0NGM0E3OTY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PqqezsUAAAAfSURBVHjaYmRABcYwBiM2QSA4y4hNEKYDQxAEAAIMAHNGAzhkPOlYAAAAAElFTkSuQmCC';
-        html = html.split('"atom://markdown-preview/assets/hr.png"').join('"data:image/png;base64,' + base64hr + '"');
+      // get the rendering preference.
+      var rend = atom.config.get('markdown-pdf.rendering');
+      var html = getHtml(rend);
+      html = prepareHtml(html);
 
-        // Ugly Fix 2:
-        html = html.split(',\n:host {').join(' {');
-        html = html.split(',\n:host').join(',');
-        html = html.split(':host').join('');
-
-        makePdf(html, outPath);
-      });
+      makePdf(html, outPath);
     }
     catch(err){
       console.log(err);
       return;
     }
   }
+};
+
+function prepareHtml(html) {
+  html = getStyledHtml(convertImgSrcToURI(html));
+
+  // Ugly Fix 1:
+  var base64hr = 'iVBORw0KGgoAAAANSUhEUgAAAAYAAAAECAYAAACtBE5DAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6OENDRjNBN0E2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6OENDRjNBN0I2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo4Q0NGM0E3ODY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo4Q0NGM0E3OTY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PqqezsUAAAAfSURBVHjaYmRABcYwBiM2QSA4y4hNEKYDQxAEAAIMAHNGAzhkPOlYAAAAAElFTkSuQmCC';
+
+  html = html.split('"atom://markdown-preview/assets/hr.png"').join('"data:image/png;base64,' + base64hr + '"');
+
+  // Ugly Fix 2:
+  html = html.split(',\n:host {').join(' {');
+  html = html.split(',\n:host').join(',');
+  html = html.split(':host').join('');
+
+  return html;
 }
 
-function getHtml(callback){
-  var rend = atom.config.get('markdown-pdf.rendering');
+function getHtml(rend){
   if(rend == "Marked"){
-    htmlFromMd(callback);
+    return htmlFromMd();
   }
   else{
-    htmlFromPreview(callback);
+    return htmlFromPreview();
   }
 }
 
-function htmlFromPreview(callback){
+function htmlFromPreview(){
   //render markdown using Atom's Markdown-Preview package
   var cb = atom.clipboard;
   if(editorSelected()){
@@ -106,12 +113,12 @@ function htmlFromPreview(callback){
     var html = cb.read();
     //put old clipboard contents back
     cb.write(old);
-    callback(html);
+    return html;
   }
   else alert('Please select the editor containing the markdown you wish to convert.');
 }
 
-function htmlFromMd(callback){
+function htmlFromMd(){
 
   //explicitly setting default options below, in case we want to further configure the renderer
   marked.setOptions({
@@ -127,7 +134,7 @@ function htmlFromMd(callback){
   if(editorSelected()){
     var md = atom.workspace.getActivePaneItem().buffer.cachedText;
     var html = marked(md);
-    callback(html);
+    return html;
   }
   else alert('Please select the editor containing the markdown you wish to convert.');
 }

--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -65,7 +65,6 @@ module.exports = {
       // get the rendering preference.
       var rend = atom.config.get('markdown-pdf.rendering');
       var html = getHtml(rend);
-      html = prepareHtml(html);
 
       makePdf(html, outPath);
     }
@@ -94,10 +93,10 @@ function prepareHtml(html) {
 
 function getHtml(rend){
   if(rend == "Marked"){
-    return htmlFromMd();
+    return prepareHtml(htmlFromMd());
   }
   else{
-    return htmlFromPreview();
+    return prepareHtml(htmlFromPreview());
   }
 }
 


### PR DESCRIPTION
I removed the callback from `getHtml()` to clean up the readability of the `convert` func. I moved the code from the callback out into `prepareHtml()`. It's just my preference to keep things looking as synchronous as possible since when I first looked at the code I thought `getHtml` was happening async.