### PR TITLE
Pass in refence for convert. Fixes #54

### DIFF
--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -47,7 +47,7 @@ module.exports = {
   },
 
   activate: function() {
-    atom.commands.add('atom-workspace', 'markdown-pdf:convert', this.convert());
+    atom.commands.add('atom-workspace', 'markdown-pdf:convert', this.convert);
   },
 
   convert: function() {


### PR DESCRIPTION
As written in https://github.com/travs/markdown-pdf/issues/54 and the comments of https://github.com/travs/markdown-pdf/commit/4dd21b379bee37da0e2e696739883452d79c9141

convert() caused an error in Atom. Without the braces it work.