### PR TITLE
Rearranged order of css includes

### DIFF
--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -105,9 +105,9 @@ function getStyles(){
   var styles = {};
   var mdpreview = atom.packages.activePackages["markdown-preview"];
 
-  styles.previewStyles = mdpreview.stylesheets[0][1];
   styles.syntaxStyles = atom.themes.getActiveThemes()[0].stylesheets[0][1];
   styles.uiStyles = atom.themes.getActiveThemes()[1].stylesheets[0][1];
+  styles.previewStyles = mdpreview.stylesheets[0][1];
   if(fs.existsSync(atom.styles.getUserStyleSheetPath(), 'utf8')){
     //add user stylesheet to html if it exists
     styles.userStyles = fs.readFileSync(atom.styles.getUserStyleSheetPath(), 'utf8');


### PR DESCRIPTION
This patch moves the including of mdpreview's styles to after the main styles are included, thus allowing Markdown Preview's "Use Github Style" option to work. This fixes #71 