### PR TITLE
Support convertion to PDF for markdown-preview-plus

### DIFF
--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -60,7 +60,8 @@ module.exports = {
 
         // Ugly Fix 1:
         base64hr = 'iVBORw0KGgoAAAANSUhEUgAAAAYAAAAECAYAAACtBE5DAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6OENDRjNBN0E2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6OENDRjNBN0I2NTZBMTFFMEI3QjRBODM4NzJDMjlGNDgiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo4Q0NGM0E3ODY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo4Q0NGM0E3OTY1NkExMUUwQjdCNEE4Mzg3MkMyOUY0OCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PqqezsUAAAAfSURBVHjaYmRABcYwBiM2QSA4y4hNEKYDQxAEAAIMAHNGAzhkPOlYAAAAAElFTkSuQmCC';
-        html = html.split('"atom://markdown-preview/assets/hr.png"').join('"data:image/png;base64,' + base64hr + '"');
+        hrURI = '"atom://' + mdpreview.name + '/assets/hr.png"'
+        html = html.split(hrURI).join('"data:image/png;base64,' + base64hr + '"');
 
         // Ugly Fix 2:
         html = html.split(',\n:host {').join(' {');
@@ -104,7 +105,6 @@ function wrapHtml(input){
 
 function getStyles(){
   var styles = {};
-  var mdpreview = atom.packages.activePackages["markdown-preview"];
 
   styles.syntaxStyles = atom.themes.getActiveThemes()[0].stylesheets[0][1];
   styles.uiStyles = atom.themes.getActiveThemes()[1].stylesheets[0][1];

--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -2,7 +2,7 @@ var fs = require("fs");
 var pdf = require('html-pdf');
 var path = require('path');
 var url = require('url');
-var mdpreview = atom.packages.activePackages["markdown-preview"];
+var mdpreview = null // Defer loading untill convert is called
 var less = require('less');
 
 module.exports = {
@@ -52,6 +52,13 @@ module.exports = {
   },
 
   convert: function() {
+    mdpreview = atom.packages.getActivePackage('markdown-preview');
+
+    // Use markdown-preview-plus if markdown-preview has been disabled
+    if(!mdpreview) {
+      mdpreview = atom.packages.getActivePackage('markdown-preview-plus');
+    }
+
     try{
       outPath = getOutputPath();
       htmlFromPreview(function(html){
@@ -82,15 +89,20 @@ function htmlFromPreview(callback){
   //render markdown using Atom's Markdown-Preview package
   var cb = atom.clipboard;
   if(editorSelected()){
-    //save old clipboard contents
-    var old = cb.read();
-    //get html on clipboard
-    mdpreview.mainModule.copyHtml();
+    if(mdpreview.name == 'markdown-preview'){
+      //save old clipboard contents
+      var old = cb.read();
+      //get html on clipboard
+      mdpreview.mainModule.copyHtml();
 
-    var html = cb.read();
-    //put old clipboard contents back
-    cb.write(old);
-    callback(html);
+      var html = cb.read();
+      //put old clipboard contents back
+      cb.write(old);
+      callback(html);
+    } else {
+      // copy parsed markdown with maths scaled 200%
+      mdpreview.mainModule.copyHtml(callback, 200)
+    }
   }
   else alert('Please select the editor containing the markdown you wish to convert.');
 }

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "dependencies": {
     "html-pdf": "0.3.x",
     "less": "^1.7.0"
+  },
+  "devDependencies": {
+    "temp": "^0.8.3"
   }
 }

--- a/spec/fixtures/simple.md
+++ b/spec/fixtures/simple.md
@@ -1,0 +1,5 @@
+*italic*
+
+**bold**
+
+> quote

--- a/spec/markdown-pdf-view-spec.coffee
+++ b/spec/markdown-pdf-view-spec.coffee
@@ -1,5 +1,0 @@
-MarkdownPdfView = require '../lib/markdown-pdf-view'
-
-describe "MarkdownPdfView", ->
-  it "has one valid test", ->
-    expect("life").toBe "easy"


### PR DESCRIPTION
Hi @travs,

Some of our users have wanted the ability to export PDF's from our fork of `markdown-preview` for a while (#48, https://github.com/Galadirith/markdown-preview-plus/issues/34 among others), I'm really sorry it's taken me so long to address this on my end.

We would love it if you felt you could support MPP in your awesome package. I've put together the necessary changes in this PR. I'll make some more specific comments on the diff's but as a general summary `markdown-pdf` will be able to export to PDF's when either `markdown-preview` or `markdown-preview-plus` is enabled, and in particular it also will export maths blocks which are a feature of our package.

I've also added specs to make sure both use cases when either markdown preview package is enabled are tested. I really hope you don't mind the changes I made to your specs, I also removed `spec/markdown-pdf-view-spec.coffee` that seemed to test a module that no longer existed.

Please let me know if you don't agree with any of my changes, the last thing I would want to do is cause any problems for you in your packages. Thanks @travs