### PR TITLE
Fix no image output

### DIFF
--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -173,7 +173,8 @@ function makePdf(inputHtml, outputPath){
 function processSrc(src){
   //make a local img src path into a "file:///absolute/path/" if it isn't already
 
-  if(url.parse(src).protocol){
+  var protocolsRegEx = /^(https?|file):$/;
+  if(protocolsRegEx.exec(url.parse(src).protocol) != null){
     //if the src already starts with "file://", "https://", etc., it's already in the right form (URI)
     return src;
   }


### PR DESCRIPTION
Only check for http(s) and file protocols, but more could easily be added to the regex.
