### PR TITLE
Fix "ReferenceError" for markdown-preview-plus and oversized equations

### DIFF
--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -90,7 +90,7 @@ var converter = {
       mdpreview.mainModule.copyHtml();  //get html on clipboard
     }
     else if (mdpreview.name === 'markdown-preview-plus') {
-      mdpreview.mainModule.copyHtml(callback, 200); // copy parsed markdown with maths scaled 200%
+      mdpreview.mainModule.copyHtml(cb.write.bind(cb), 200); // copy parsed markdown with maths scaled 200%
     }
 
     this.dataString = cb.read();

--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -90,7 +90,7 @@ var converter = {
       mdpreview.mainModule.copyHtml();  //get html on clipboard
     }
     else if (mdpreview.name === 'markdown-preview-plus') {
-      mdpreview.mainModule.copyHtml(cb.write.bind(cb), 200); // copy parsed markdown with maths scaled 200%
+      mdpreview.mainModule.copyHtml(cb.write.bind(cb));
     }
 
     this.dataString = cb.read();


### PR DESCRIPTION
When the markdown-preview package is disabled, markdown-pdf attempts to use markdown-preview-plus but gets a ReferenceError.
