### PR TITLE
Make applicable units font-size relative.

### DIFF
--- a/lib/github-markdown.css
+++ b/lib/github-markdown.css
@@ -47,7 +47,7 @@
 .markdown-body code,
 .markdown-body kbd,
 .markdown-body pre {
-  font-family: monospace, monospace;
+  font-family: monospace;
   font-size: 1em;
 }
 
@@ -85,7 +85,7 @@
 }
 
 .markdown-body input {
-  font: 13px / 1.4 Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font: .8125em / 1.4 Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
 .markdown-body a {
@@ -100,7 +100,7 @@
 
 .markdown-body hr {
   height: 0;
-  margin: 15px 0;
+  margin: .9375em 0;
   overflow: hidden;
   background: transparent;
   border: 0;
@@ -124,33 +124,33 @@
 .markdown-body h4,
 .markdown-body h5,
 .markdown-body h6 {
-  margin-top: 15px;
-  margin-bottom: 15px;
+  margin-top: .9375em;
+  margin-bottom: .9375em;
   line-height: 1.1;
 }
 
 .markdown-body h1 {
-  font-size: 30px;
+  font-size: 1.875em;
 }
 
 .markdown-body h2 {
-  font-size: 21px;
+  font-size: 1.3125em;
 }
 
 .markdown-body h3 {
-  font-size: 16px;
+  font-size: 1em;
 }
 
 .markdown-body h4 {
-  font-size: 14px;
+  font-size: 0.875em;
 }
 
 .markdown-body h5 {
-  font-size: 12px;
+  font-size: 0.75em;
 }
 
 .markdown-body h6 {
-  font-size: 11px;
+  font-size: 0.6875em;
 }
 
 .markdown-body blockquote {
@@ -182,13 +182,13 @@
 
 .markdown-body code {
   font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
-  font-size: 12px;
+  font-size: 0.75em;
 }
 
 .markdown-body pre {
   margin-top: 0;
   margin-bottom: 0;
-  font: 12px Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font: 0.75em Consolas, "Liberation Mono", Menlo, Courier, monospace;
 }
 
 .markdown-body .select::-ms-expand {
@@ -239,7 +239,7 @@
 .markdown-body .anchor {
   display: inline-block;
   padding-right: 2px;
-  margin-left: -18px;
+  margin-left: -1.125em;
 }
 
 .markdown-body .anchor:focus {
@@ -253,7 +253,7 @@
 .markdown-body h5,
 .markdown-body h6 {
   margin-top: 1em;
-  margin-bottom: 16px;
+  margin-bottom: 1em;
   font-weight: bold;
   line-height: 1.4;
 }
@@ -351,13 +351,13 @@
 .markdown-body table,
 .markdown-body pre {
   margin-top: 0;
-  margin-bottom: 16px;
+  margin-bottom: 1em;
 }
 
 .markdown-body hr {
-  height: 4px;
+  height: .25em;
   padding: 0;
-  margin: 16px 0;
+  margin: 1em 0;
   background-color: #e7e7e7;
   border: 0 none;
 }
@@ -376,7 +376,7 @@
 }
 
 .markdown-body li>p {
-  margin-top: 16px;
+  margin-top: 1em;
 }
 
 .markdown-body dl {
@@ -385,21 +385,21 @@
 
 .markdown-body dl dt {
   padding: 0;
-  margin-top: 16px;
+  margin-top: 1em;
   font-size: 1em;
   font-style: italic;
   font-weight: bold;
 }
 
 .markdown-body dl dd {
-  padding: 0 16px;
-  margin-bottom: 16px;
+  padding: 0 1em;
+  margin-bottom: 1em;
 }
 
 .markdown-body blockquote {
-  padding: 0 15px;
+  padding: 0 .9375em;
   color: #777;
-  border-left: 4px solid #ddd;
+  border-left: .25em solid #ddd;
 }
 
 .markdown-body blockquote>:first-child {
@@ -424,7 +424,7 @@
 
 .markdown-body table th,
 .markdown-body table td {
-  padding: 6px 13px;
+  padding: .375em .8125em;
   border: 1px solid #ddd;
 }
 
@@ -470,12 +470,12 @@
 }
 
 .markdown-body .highlight {
-  margin-bottom: 16px;
+  margin-bottom: 1em;
 }
 
 .markdown-body .highlight pre,
 .markdown-body pre {
-  padding: 16px;
+  padding: 1em;
   overflow: auto;
   font-size: 85%;
   line-height: 1.45;
@@ -610,9 +610,9 @@
 
 .markdown-body kbd {
   display: inline-block;
-  padding: 3px 5px;
-  font: 11px Consolas, "Liberation Mono", Menlo, Courier, monospace;
-  line-height: 10px;
+  padding: .1875em .3125em;
+  font: .6875em Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  line-height: .625em;
   color: #555;
   vertical-align: middle;
   background-color: #fcfcfc;
@@ -627,7 +627,7 @@
 }
 
 .markdown-body .task-list-item+.task-list-item {
-  margin-top: 3px;
+  margin-top: .1875em;
 }
 
 .markdown-body .task-list-item input {

--- a/lib/github-markdown.css
+++ b/lib/github-markdown.css
@@ -509,20 +509,6 @@
   content: normal;
 }
 
-.markdown-body kbd {
-  display: inline-block;
-  padding: 3px 5px;
-  font-size: 11px;
-  line-height: 10px;
-  color: #555;
-  vertical-align: middle;
-  background-color: #fcfcfc;
-  border: solid 1px #ccc;
-  border-bottom-color: #bbb;
-  border-radius: 3px;
-  box-shadow: inset 0 -1px 0 #bbb;
-}
-
 .markdown-body .pl-c {
   color: #969896;
 }


### PR DESCRIPTION
Make font-sizes, margins and paddings relative where applicable. This
means the whole document can easily be sized up or down by setting a
font-size on `.markdown-body`.

Additionally, remove a whole redundant duplicate selector section from the file for `.markdown-body kbd`, namely [L512](https://github.com/travs/markdown-pdf/blob/master/lib/github-markdown.css#L512) and [L625](https://github.com/travs/markdown-pdf/blob/master/lib/github-markdown.css#L625) duplicating each other.

Minor redundant `font-family` declaration removed.
