### PR TITLE
[Fix] Break lines in code block

### DIFF
--- a/lib/github-markdown.css
+++ b/lib/github-markdown.css
@@ -49,6 +49,7 @@
 .markdown-body pre {
   font-family: monospace, monospace;
   font-size: 1em;
+  word-wrap: break-word;
 }
 
 .markdown-body input {


### PR DESCRIPTION
Now, line breaking doesn't work in code block. So I suggest to add just one line in CSS to fix this bug.

Before
![image](https://cloud.githubusercontent.com/assets/8326452/22415814/820f2e36-e70d-11e6-976c-d6566776b8bb.png)

After
![image](https://cloud.githubusercontent.com/assets/8326452/22415794/5f57da46-e70d-11e6-8aee-bf85b4b1a31b.png)
