### PR TITLE
Fix race condition when compiling user stylesheets

### DIFF
--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -72,10 +72,12 @@ module.exports = {
 
       outPath = getOutputPath();
       html = converter.htmlFromPreview()
-        .convertImgSrcToURI()
-        .styleHtml()
-        .uglyFix();
-      makePdf(html, outPath);
+        .convertImgSrcToURI();
+
+      converter.styleHtml(function (that) {
+        html = that.uglyFix();
+        makePdf(html, outPath);
+      });
     }
     catch(err){
       atom.notifications.addError('markdown-pdf: ' + err, {dismissable: true});
@@ -121,35 +123,44 @@ var converter = {
     return this;
   },
 
-  styleHtml: function () {
+  getUserStyles: function (cb) {
+    var upath = atom.styles.getUserStyleSheetPath();
+
+    if (fs.existsSync(upath, 'utf8')) {
+      // add user stylesheet to html if it exists
+      var ustyle = fs.readFileSync(upath, 'utf8');
+
+      // compiling less to css if file extension is .less
+      if (upath.substr(upath.length - 5).toLowerCase() === '.less') {
+        less.render(ustyle, function (e, output) {
+          cb(output);
+        });
+      } else {
+        cb(ustyle);
+      }
+    } else {
+      cb('');
+    }
+  },
+
+  styleHtml: function (cb) {
+    var that = this;
     var wrappedHtml = '<body class="markdown-preview native-key-binding markdown-body">' + this.dataString + '</body>';
 
     var styles = {};
     styles.gfmstyles = fs.readFileSync(__dirname + '/github-markdown.css', 'utf-8');
     styles.syntaxStyles = atom.themes.getActiveThemes()[0].stylesheets[0][1];
 
-    if(fs.existsSync(atom.styles.getUserStyleSheetPath(), 'utf8')){
-      //add user stylesheet to html if it exists
-      var upath = atom.styles.getUserStyleSheetPath();
-      var ustyle = fs.readFileSync(upath, 'utf8');
+    this.getUserStyles(function (output) {
+      styles.userStyles = output;
 
-      // compiling less to css if file extension is .less
-      if (upath.substr(upath.length - 5).toLowerCase() == '.less') {
-        less.render(ustyle, function(e, output) {
-          styles.userStyles = output;
-        });
+      var styleString = '';
+      for(var s in styles){
+        styleString += '<style>' + styles[s] + '</style>';
       }
-      else {
-        styles.userStyles = ustyle;
-      }
-    }
-
-    var styleString = '';
-    for(var s in styles){
-      styleString += '<style>' + styles[s] + '</style>';
-    }
-    this.dataString = styleString + wrappedHtml;
-    return this;
+      that.dataString = styleString + wrappedHtml;
+      cb(that);
+    });
   },
 
   uglyFix: function () {


### PR DESCRIPTION
I just found a race condition when compiling the `styles.less` stylesheet. It could lead to an empty `styles.userStyles` because the assignment in the `less.render()` callback is called after generating the `styleString` when compiling larger stylesheets.

This PR fixes these cases.