### PR TITLE
Fix bug so output directory can be set

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -31,7 +31,7 @@ function getOutputPath(inputPath) {
   let outputPath;
   const userConfigOutputDir = atom.config.get('markdown-pdf.outputDir');
   if (userConfigOutputDir) {
-    outputDir = path.resolve(conf.outputDir);
+    outputDir = path.resolve(userConfigOutputDir);
   }
   if (!inputPath){  // converting an unsaved file
     atom.notifications.addWarning(


### PR DESCRIPTION
When using the "Override output directory" setting, I was getting an error that 'conf' was undefined. This fixes the problem.